### PR TITLE
fix(ui): align bg-card usage to B05 luminance spec

### DIFF
--- a/dashboard/src/components/charts/stat-card.tsx
+++ b/dashboard/src/components/charts/stat-card.tsx
@@ -59,7 +59,7 @@ export function StatCard({
           )}
         </div>
         {Icon && (
-          <div className={cn("rounded-md bg-card p-2", iconColor)}>
+          <div className={cn("rounded-md bg-background p-2", iconColor)}>
             <Icon className="h-5 w-5" strokeWidth={1.5} />
           </div>
         )}

--- a/dashboard/src/views/day/raw-footprint-data.tsx
+++ b/dashboard/src/views/day/raw-footprint-data.tsx
@@ -65,25 +65,25 @@ export function RawFootprintData({ data }: RawFootprintDataProps) {
               <div>
                 <h3 className="text-sm font-normal text-muted-foreground mb-2">轨迹概览</h3>
                 <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-                  <div className="rounded-widget bg-card p-3">
+                  <div className="rounded-widget bg-secondary p-3">
                     <div className="text-xs text-muted-foreground">总距离</div>
                     <div className="text-xl font-semibold font-display tracking-tight">
                       {formatDistance(data.summary.totalDistance)}
                     </div>
                   </div>
-                  <div className="rounded-widget bg-card p-3">
+                  <div className="rounded-widget bg-secondary p-3">
                     <div className="text-xs text-muted-foreground">平均速度</div>
                     <div className="text-xl font-semibold font-display tracking-tight">
                       {formatSpeed(data.summary.avgSpeed)}
                     </div>
                   </div>
-                  <div className="rounded-widget bg-card p-3">
+                  <div className="rounded-widget bg-secondary p-3">
                     <div className="text-xs text-muted-foreground">轨迹点数</div>
                     <div className="text-xl font-semibold font-display tracking-tight">
                       {data.summary.pointCount.toLocaleString()}
                     </div>
                   </div>
-                  <div className="rounded-widget bg-card p-3">
+                  <div className="rounded-widget bg-secondary p-3">
                     <div className="text-xs text-muted-foreground">记录时间</div>
                     <div className="text-lg font-semibold">
                       {data.summary.minTime} - {data.summary.maxTime}

--- a/dashboard/src/views/day/raw-health-data.tsx
+++ b/dashboard/src/views/day/raw-health-data.tsx
@@ -53,24 +53,24 @@ export function RawHealthData({ data }: RawHealthDataProps) {
         <div className="space-y-6">
             {/* Summary Cards - Row 1: Core Metrics */}
             <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-              <div className="rounded-widget bg-card p-3">
+              <div className="rounded-widget bg-secondary p-3">
                 <div className="text-xs text-muted-foreground">总步数</div>
                 <div className="text-xl font-semibold font-display tracking-tight">
                   {data.totalSteps.toLocaleString()}
                 </div>
               </div>
-              <div className="rounded-widget bg-card p-3">
+              <div className="rounded-widget bg-secondary p-3">
                 <div className="text-xs text-muted-foreground">步行距离</div>
                 <div className="text-xl font-semibold font-display tracking-tight">
                   {data.distance ? `${data.distance.total.toFixed(2)} km` : "-"}
                 </div>
               </div>
-              <div className="rounded-widget bg-card p-3">
+              <div className="rounded-widget bg-secondary p-3">
                 <div className="text-xs text-muted-foreground">攀爬楼层</div>
                 <div className="text-xl font-semibold font-display tracking-tight">{data.flightsClimbed} 层</div>
               </div>
               {data.activity && (
-                <div className="rounded-widget bg-card p-3">
+                <div className="rounded-widget bg-secondary p-3">
                   <div className="text-xs text-muted-foreground">活动能量</div>
                   <div className="text-xl font-semibold font-display tracking-tight">
                     {Math.round(data.activity.activeEnergy)} kcal
@@ -82,20 +82,20 @@ export function RawHealthData({ data }: RawHealthDataProps) {
             {/* Summary Cards - Row 2: Activity */}
             {data.activity && (
               <div className="grid grid-cols-3 gap-3">
-                <div className="rounded-widget bg-card p-3 text-center">
+                <div className="rounded-widget bg-secondary p-3 text-center">
                   <div className="text-xs text-muted-foreground">运动时间</div>
                   <div className="text-lg font-semibold text-green-500">
                     {data.activity.exerciseMinutes} 分钟
                   </div>
                 </div>
-                <div className="rounded-widget bg-card p-3 text-center">
+                <div className="rounded-widget bg-secondary p-3 text-center">
                   <div className="text-xs text-muted-foreground">站立小时</div>
                   <div className="text-lg font-semibold text-cyan-500">
                     {data.activity.standHours} 小时
                   </div>
                 </div>
                 {data.sleepingWristTemperature && (
-                  <div className="rounded-widget bg-card p-3 text-center">
+                  <div className="rounded-widget bg-secondary p-3 text-center">
                     <div className="text-xs text-muted-foreground">睡眠腕温</div>
                     <div className="text-lg font-semibold">
                       {data.sleepingWristTemperature}°C
@@ -109,7 +109,7 @@ export function RawHealthData({ data }: RawHealthDataProps) {
             {data.sleep && (
               <div>
                 <h3 className="text-sm font-normal text-muted-foreground mb-2">睡眠分析</h3>
-                <div className="rounded-widget bg-card p-3 space-y-3">
+                <div className="rounded-widget bg-secondary p-3 space-y-3">
                   <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
                     <div>
                       <div className="text-xs text-muted-foreground">总时长</div>
@@ -187,26 +187,26 @@ export function RawHealthData({ data }: RawHealthDataProps) {
               <div>
                 <h3 className="text-sm font-normal text-muted-foreground mb-2">心率</h3>
                 <div className="grid grid-cols-3 md:grid-cols-5 gap-3 mb-3">
-                  <div className="rounded-widget bg-card p-3 text-center">
+                  <div className="rounded-widget bg-secondary p-3 text-center">
                     <div className="text-xs text-muted-foreground">平均</div>
                     <div className="text-lg font-semibold">
                       {data.heartRate.avg} bpm
                     </div>
                   </div>
-                  <div className="rounded-widget bg-card p-3 text-center">
+                  <div className="rounded-widget bg-secondary p-3 text-center">
                     <div className="text-xs text-muted-foreground">最低</div>
                     <div className="text-lg font-semibold text-blue-500">
                       {data.heartRate.min} bpm
                     </div>
                   </div>
-                  <div className="rounded-widget bg-card p-3 text-center">
+                  <div className="rounded-widget bg-secondary p-3 text-center">
                     <div className="text-xs text-muted-foreground">最高</div>
                     <div className="text-lg font-semibold text-red-500">
                       {data.heartRate.max} bpm
                     </div>
                   </div>
                   {data.heartRate.restingHeartRate && (
-                    <div className="rounded-widget bg-card p-3 text-center">
+                    <div className="rounded-widget bg-secondary p-3 text-center">
                       <div className="text-xs text-muted-foreground">静息</div>
                       <div className="text-lg font-semibold text-green-500">
                         {data.heartRate.restingHeartRate} bpm
@@ -214,7 +214,7 @@ export function RawHealthData({ data }: RawHealthDataProps) {
                     </div>
                   )}
                   {data.heartRate.walkingAverage && (
-                    <div className="rounded-widget bg-card p-3 text-center">
+                    <div className="rounded-widget bg-secondary p-3 text-center">
                       <div className="text-xs text-muted-foreground">步行</div>
                       <div className="text-lg font-semibold text-orange-500">
                         {data.heartRate.walkingAverage} bpm
@@ -262,19 +262,19 @@ export function RawHealthData({ data }: RawHealthDataProps) {
               <div>
                 <h3 className="text-sm font-normal text-muted-foreground mb-2">血氧饱和度</h3>
                 <div className="grid grid-cols-3 gap-3 mb-3">
-                  <div className="rounded-widget bg-card p-3 text-center">
+                  <div className="rounded-widget bg-secondary p-3 text-center">
                     <div className="text-xs text-muted-foreground">平均</div>
                     <div className="text-lg font-semibold">
                       {data.oxygenSaturation.avg}%
                     </div>
                   </div>
-                  <div className="rounded-widget bg-card p-3 text-center">
+                  <div className="rounded-widget bg-secondary p-3 text-center">
                     <div className="text-xs text-muted-foreground">最低</div>
                     <div className="text-lg font-semibold text-yellow-500">
                       {data.oxygenSaturation.min}%
                     </div>
                   </div>
-                  <div className="rounded-widget bg-card p-3 text-center">
+                  <div className="rounded-widget bg-secondary p-3 text-center">
                     <div className="text-xs text-muted-foreground">最高</div>
                     <div className="text-lg font-semibold text-green-500">
                       {data.oxygenSaturation.max}%
@@ -316,19 +316,19 @@ export function RawHealthData({ data }: RawHealthDataProps) {
               <div>
                 <h3 className="text-sm font-normal text-muted-foreground mb-2">呼吸频率</h3>
                 <div className="grid grid-cols-3 gap-3 mb-3">
-                  <div className="rounded-widget bg-card p-3 text-center">
+                  <div className="rounded-widget bg-secondary p-3 text-center">
                     <div className="text-xs text-muted-foreground">平均</div>
                     <div className="text-lg font-semibold">
                       {data.respiratoryRate.avg} 次/分
                     </div>
                   </div>
-                  <div className="rounded-widget bg-card p-3 text-center">
+                  <div className="rounded-widget bg-secondary p-3 text-center">
                     <div className="text-xs text-muted-foreground">最低</div>
                     <div className="text-lg font-semibold text-blue-500">
                       {data.respiratoryRate.min} 次/分
                     </div>
                   </div>
-                  <div className="rounded-widget bg-card p-3 text-center">
+                  <div className="rounded-widget bg-secondary p-3 text-center">
                     <div className="text-xs text-muted-foreground">最高</div>
                     <div className="text-lg font-semibold text-red-500">
                       {data.respiratoryRate.max} 次/分
@@ -370,19 +370,19 @@ export function RawHealthData({ data }: RawHealthDataProps) {
               <div>
                 <h3 className="text-sm font-normal text-muted-foreground mb-2">心率变异性 (HRV)</h3>
                 <div className="grid grid-cols-3 gap-3 mb-3">
-                  <div className="rounded-widget bg-card p-3 text-center">
+                  <div className="rounded-widget bg-secondary p-3 text-center">
                     <div className="text-xs text-muted-foreground">平均</div>
                     <div className="text-lg font-semibold">
                       {data.hrv.avg} ms
                     </div>
                   </div>
-                  <div className="rounded-widget bg-card p-3 text-center">
+                  <div className="rounded-widget bg-secondary p-3 text-center">
                     <div className="text-xs text-muted-foreground">最低</div>
                     <div className="text-lg font-semibold text-yellow-500">
                       {data.hrv.min} ms
                     </div>
                   </div>
-                  <div className="rounded-widget bg-card p-3 text-center">
+                  <div className="rounded-widget bg-secondary p-3 text-center">
                     <div className="text-xs text-muted-foreground">最高</div>
                     <div className="text-lg font-semibold text-green-500">
                       {data.hrv.max} ms

--- a/dashboard/src/views/day/raw-pixiu-data.tsx
+++ b/dashboard/src/views/day/raw-pixiu-data.tsx
@@ -35,19 +35,19 @@ export function RawPixiuData({ data }: RawPixiuDataProps) {
               <div>
                 <h3 className="text-sm font-normal text-muted-foreground mb-2">日收支概览</h3>
                 <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-                  <div className="rounded-widget bg-card p-3">
+                  <div className="rounded-widget bg-secondary p-3">
                     <div className="text-xs text-muted-foreground">收入</div>
                     <div className="text-xl font-semibold font-display tracking-tight text-green-600">
                       +¥{data.summary.income.toFixed(2)}
                     </div>
                   </div>
-                  <div className="rounded-widget bg-card p-3">
+                  <div className="rounded-widget bg-secondary p-3">
                     <div className="text-xs text-muted-foreground">支出</div>
                     <div className="text-xl font-semibold font-display tracking-tight text-red-500">
                       -¥{data.summary.expense.toFixed(2)}
                     </div>
                   </div>
-                  <div className="rounded-widget bg-card p-3">
+                  <div className="rounded-widget bg-secondary p-3">
                     <div className="text-xs text-muted-foreground">净收入</div>
                     <div
                       className={`text-xl font-semibold font-display tracking-tight ${
@@ -58,7 +58,7 @@ export function RawPixiuData({ data }: RawPixiuDataProps) {
                       {data.summary.net.toFixed(2)}
                     </div>
                   </div>
-                  <div className="rounded-widget bg-card p-3">
+                  <div className="rounded-widget bg-secondary p-3">
                     <div className="text-xs text-muted-foreground">交易笔数</div>
                     <div className="text-xl font-semibold font-display tracking-tight">
                       {data.summary.transactionCount}

--- a/dashboard/src/views/month/month-footprint-panel.tsx
+++ b/dashboard/src/views/month/month-footprint-panel.tsx
@@ -152,7 +152,7 @@ export function MonthFootprintPanel({ data }: MonthFootprintPanelProps) {
               return (
                 <div
                   key={mode.mode}
-                  className="flex items-center gap-2.5 rounded-widget bg-card p-2.5"
+                  className="flex items-center gap-2.5 rounded-widget bg-secondary p-2.5"
                 >
                   <div className="rounded-md bg-muted p-1.5">
                     <Icon className="h-4 w-4 text-muted-foreground" strokeWidth={1.5} aria-hidden="true" />

--- a/dashboard/src/views/year/year-footprint-panel.tsx
+++ b/dashboard/src/views/year/year-footprint-panel.tsx
@@ -181,7 +181,7 @@ export function YearFootprintPanel({ data, year }: YearFootprintPanelProps) {
                 return (
                   <div
                     key={mode.mode}
-                    className="flex items-center gap-2.5 rounded-widget bg-card p-2.5"
+                    className="flex items-center gap-2.5 rounded-widget bg-secondary p-2.5"
                   >
                     <div className="rounded-md bg-muted p-1.5">
                       <Icon className="h-4 w-4 text-muted-foreground" strokeWidth={1.5} aria-hidden="true" />


### PR DESCRIPTION
Closes #7\n\nReplace misused bg-card (L1) with bg-secondary (L2) for content cards inside the floating island, per Basalt B05 spec.