### PR TITLE
ci: enable security scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,5 @@ jobs:
       test-command: "bun run ut"
       lint-command: "bun run lint"
       typecheck-command: "true"
-      enable-security: "false"
       enable-l2: "false"
     secrets: inherit


### PR DESCRIPTION
Enable security scan (gitleaks + osv-scanner) by removing `enable-security: false`. Repo has no vulnerabilities.