### PR TITLE
ci(l2): enable L2 gate in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,5 +15,6 @@ jobs:
       test-command: "bun run test:coverage"
       lint-command: "bun run lint"
       typecheck-command: "true"
-      enable-l2: "false"
+      enable-l2: "true"
+      l2-command: "bun run test:l2"
     secrets: inherit

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test:coverage": "bun --bun vitest run --coverage && bun run scripts/coverage-check.ts && cd dashboard && bun run ut",
     "ut": "bun --bun vitest run --coverage && bun run scripts/coverage-check.ts && cd dashboard && bun run ut",
     "ut:scripts": "bun --bun vitest run --coverage && bun run scripts/coverage-check.ts",
+    "test:l2": "cd dashboard && bunx vitest run tests/api/",
     "lint": "eslint --max-warnings=0 . --ext .ts && cd dashboard && bun run lint",
     "lint:import": "eslint scripts/import --ext .ts",
     "lint:verify": "eslint scripts/verify --ext .ts",


### PR DESCRIPTION
Add/fix `test:l2` script and enable `enable-l2: true` in base-ci workflow.

L2 tests verified locally:
- All route-level integration tests pass
- CI L2 job will run as a separate parallel step