### PR TITLE
test(l3): scaffold Playwright BDD for dashboard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,7 @@ jobs:
       typecheck-command: "true"
       enable-l2: "true"
       l2-command: "bun run test:l2"
+      enable-l3: "true"
+      l3-command: "bun run test:e2e:bdd"
+      l3-browser: "chromium"
     secrets: inherit

--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -4,3 +4,5 @@ coverage/
 *.tsbuildinfo
 next-env.d.ts
 .env.local
+playwright-report/
+test-results/

--- a/dashboard/bun.lock
+++ b/dashboard/bun.lock
@@ -34,6 +34,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "^4.3.1",
         "@testing-library/react": "^16.3.2",
         "@types/better-sqlite3": "^7.6.13",
@@ -243,6 +244,8 @@
     "@oxc-project/types": ["@oxc-project/types@0.127.0", "", {}, "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ=="],
 
     "@panva/hkdf": ["@panva/hkdf@1.2.1", "", {}, "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw=="],
+
+    "@playwright/test": ["@playwright/test@1.60.0", "", { "dependencies": { "playwright": "1.60.0" }, "bin": { "playwright": "cli.js" } }, "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.2", "", {}, "sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig=="],
 
@@ -830,7 +833,7 @@
 
     "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -1115,6 +1118,10 @@
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "playwright": ["playwright@1.60.0", "", { "dependencies": { "playwright-core": "1.60.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA=="],
+
+    "playwright-core": ["playwright-core@1.60.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -1605,6 +1612,8 @@
     "sharp/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
     "tsconfig-paths/json5": ["json5@1.0.2", "", { "dependencies": { "minimist": "^1.2.0" }, "bin": { "json5": "lib/cli.js" } }, "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA=="],
+
+    "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "@radix-ui/react-alert-dialog/@radix-ui/react-dialog/@radix-ui/react-id": ["@radix-ui/react-id@1.1.2", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA=="],
 

--- a/dashboard/e2e/bdd/app.spec.ts
+++ b/dashboard/e2e/bdd/app.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Dashboard — BDD Smoke", () => {
+  test("Given the dashboard is running, When I visit the login page, Then I see the welcome badge", async ({
+    page,
+  }) => {
+    // Given: app is running on the E2E port (webServer in playwright.config.ts)
+
+    // When: visit the public login route
+    await page.goto("/login");
+
+    // Then: the document title is set by the root layout
+    await expect(page).toHaveTitle(/life\.ai/, { timeout: 15_000 });
+
+    // And: the login card shows the Google sign-in entry point
+    await expect(
+      page.getByRole("button", { name: /Continue with Google/i }),
+    ).toBeVisible();
+  });
+});

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4.3.1",
     "@testing-library/react": "^16.3.2",
     "@types/better-sqlite3": "^7.6.13",

--- a/dashboard/playwright.config.ts
+++ b/dashboard/playwright.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
   },
   webServer: {
     command:
-      "AUTH_SECRET=e2e-placeholder-secret AUTH_GOOGLE_ID=e2e-placeholder AUTH_GOOGLE_SECRET=e2e-placeholder bun run dev -- -p 27011",
+      "AUTH_SECRET=e2e-placeholder-secret AUTH_GOOGLE_ID=e2e-placeholder AUTH_GOOGLE_SECRET=e2e-placeholder bunx next dev -p 27011 --turbopack",
     port: 27011,
     reuseExistingServer: !process.env.CI,
     timeout: 60_000,

--- a/dashboard/playwright.config.ts
+++ b/dashboard/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e/bdd",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : 2,
+  reporter: "html",
+  use: {
+    baseURL: "http://localhost:27011",
+    trace: "on-first-retry",
+    headless: true,
+  },
+  webServer: {
+    command:
+      "AUTH_SECRET=e2e-placeholder-secret AUTH_GOOGLE_ID=e2e-placeholder AUTH_GOOGLE_SECRET=e2e-placeholder bun run dev -- -p 27011",
+    port: 27011,
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "ut": "bun --bun vitest run --coverage && bun run scripts/coverage-check.ts && cd dashboard && bun run ut",
     "ut:scripts": "bun --bun vitest run --coverage && bun run scripts/coverage-check.ts",
     "test:l2": "cd dashboard && bunx vitest run tests/api/",
+    "test:e2e:bdd": "cd dashboard && bunx playwright test",
     "lint": "eslint --max-warnings=0 . --ext .ts && cd dashboard && bun run lint",
     "lint:import": "eslint scripts/import --ext .ts",
     "lint:verify": "eslint scripts/verify --ext .ts",


### PR DESCRIPTION
## Summary
- Add Playwright BDD scaffold under `dashboard/` with a smoke test for the public login page.
- Add root `test:e2e:bdd` script.
- Enable L3 BDD in CI via `nocoo/base-ci@v2026.4`.
- Invoke Next dev directly from Playwright webServer to avoid ambiguous duplicate `-p` flags.

## Verification
- `bun run test:e2e:bdd` passed (SDE + reviewer)
- `cd dashboard && bun run lint` passed (reviewer)
- `git diff --check 8c86a69..de88af3` passed (reviewer)

Multica issue: STU-577
