### PR TITLE
chore(deps): bump better-sqlite3 12.10.0 → 12.10.1

### DIFF
--- a/dashboard/bun.lock
+++ b/dashboard/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@googlemaps/js-api-loader": "^2.1.1",
         "@types/google.maps": "^3.65.1",
-        "better-sqlite3": "^12.10.0",
+        "better-sqlite3": "12.10.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -629,7 +629,7 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.14", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-fOVLPAsFTsQfuCkvahZkzq6nf8KvGWanlYoTh0SVA0A/PIUxQGU2AOZAoD95n2gFLVDW/jP6sbGLny95nmEuHA=="],
 
-    "better-sqlite3": ["better-sqlite3@12.10.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ=="],
+    "better-sqlite3": ["better-sqlite3@12.10.1", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-HfFtzCqnSfwB3+HroF6PSKzyh+7RfNMGPCzHFUZXRlvrPCb4P3cvxKZNN43Sr7IrkofqQZM+gIvffGpA8VvqgA=="],
 
     "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
 

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@googlemaps/js-api-loader": "^2.1.1",
     "@types/google.maps": "^3.65.1",
-    "better-sqlite3": "^12.10.0",
+    "better-sqlite3": "^12.10.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",


### PR DESCRIPTION
## Summary

- Patch upgrade `better-sqlite3` in `dashboard` workspace: `12.10.0` → `12.10.1`.
- Lockfile updated via `bun add better-sqlite3@12.10.1`.

## Verification

- `cd dashboard && bun run ut` — 47 test files, 557 tests passed. Coverage thresholds intact (Statements 99.51%, Branches 95.94%, Functions 99.38%, Lines 99.73%).

Closes nocoo/life.ai#83