### PR TITLE
chore(deps): bump happy-dom 20.10.5 & lucide-react 1.20.0 in dashboard

### DIFF
--- a/dashboard/bun.lock
+++ b/dashboard/bun.lock
@@ -50,7 +50,7 @@
         "@vitest/coverage-istanbul": "^4.1.9",
         "eslint": "^10.5.0",
         "eslint-config-next": "^16.2.9",
-        "happy-dom": "^20.10.4",
+        "happy-dom": "^20.10.5",
         "tailwindcss": "^4.3.1",
         "typescript": "^6.0.3",
         "vitest": "^4.1.9",
@@ -869,7 +869,7 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
-    "happy-dom": ["happy-dom@20.10.4", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-bKrsQnFNpcjZG0UPsH7UMN7Oyp3AB42LXk2GuiQmu7l4QFxH7lsw5T1eWEtE2+vbIFrTC45sbNSB2pkB8MTfKA=="],
+    "happy-dom": ["happy-dom@20.10.5", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-0aA6BQoMnpcRE/c1E8ZyF2jXnET7MJskereWOXher4CJuYjrI5esN0Az/1NPMD4KeWUbampBGw2MGqabMPFIbg=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 

--- a/dashboard/bun.lock
+++ b/dashboard/bun.lock
@@ -16,7 +16,7 @@
         "leaflet-draw": "^1.0.4",
         "leaflet.fullscreen": "^5.3.1",
         "leaflet.markercluster": "^1.5.3",
-        "lucide-react": "^1.18.0",
+        "lucide-react": "^1.20.0",
         "next": "^16.2.9",
         "next-auth": "^5.0.0-beta.30",
         "next-themes": "^0.4.6",
@@ -1035,7 +1035,7 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
-    "lucide-react": ["lucide-react@1.18.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-LZDb7H/0YfM+RJncD0hDQRCAu+vSGODqpe35TuVI8EuXaRjkczbsx7p8dY4J87F/MUSj6bpYqeI8nw8qXaAdmA=="],
+    "lucide-react": ["lucide-react@1.20.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-jhXLeC/7m0/tjL1nzMdKk6x256zWA6AtbhTVreHOiKPoeX2d6MK4FbyIQPpVq0E6iPWBisyy1TW+pEge/uMEuQ=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -56,7 +56,7 @@
     "@vitest/coverage-istanbul": "^4.1.9",
     "eslint": "^10.5.0",
     "eslint-config-next": "^16.2.9",
-    "happy-dom": "^20.10.4",
+    "happy-dom": "^20.10.5",
     "tailwindcss": "^4.3.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -22,7 +22,7 @@
     "leaflet-draw": "^1.0.4",
     "leaflet.fullscreen": "^5.3.1",
     "leaflet.markercluster": "^1.5.3",
-    "lucide-react": "^1.18.0",
+    "lucide-react": "^1.20.0",
     "next": "^16.2.9",
     "next-auth": "^5.0.0-beta.30",
     "next-themes": "^0.4.6",


### PR DESCRIPTION
## Summary

Batch dependency upgrade for the `dashboard/` workspace, two atomic commits:

- `b0f1c8d` — happy-dom `^20.10.4` → `^20.10.5` (devDependencies, patch) — Closes #96
- `cf6dd51` — lucide-react `^1.18.0` → `^1.20.0` (dependencies, minor) — Closes #97

Caret ranges preserved to stay consistent with the rest of the manifest; `bun.lock` package specs synced accordingly. Diff is limited to `dashboard/package.json` and `dashboard/bun.lock`.

## Test plan

- [x] `bun install --frozen-lockfile` — lockfile consistent, no changes
- [x] `bun run lint` — 0 warnings
- [x] `bun run ut` — 47 files / 557 tests passing, 99.51% stmts coverage
- [x] `bun run build` — Next.js build succeeds, 24/24 static pages
- [x] Reviewed and approved by Reviewer-03