### PR TITLE
chore(deps): bump happy-dom

### DIFF
--- a/dashboard/bun.lock
+++ b/dashboard/bun.lock
@@ -50,7 +50,7 @@
         "@vitest/coverage-istanbul": "^4.1.9",
         "eslint": "^10.5.0",
         "eslint-config-next": "^16.2.9",
-        "happy-dom": "20.10.6",
+        "happy-dom": "^20.10.6",
         "tailwindcss": "^4.3.1",
         "typescript": "^6.0.3",
         "vitest": "^4.1.9",

--- a/dashboard/bun.lock
+++ b/dashboard/bun.lock
@@ -50,7 +50,7 @@
         "@vitest/coverage-istanbul": "^4.1.9",
         "eslint": "^10.5.0",
         "eslint-config-next": "^16.2.9",
-        "happy-dom": "^20.10.5",
+        "happy-dom": "20.10.6",
         "tailwindcss": "^4.3.1",
         "typescript": "^6.0.3",
         "vitest": "^4.1.9",
@@ -869,7 +869,7 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
-    "happy-dom": ["happy-dom@20.10.5", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-0aA6BQoMnpcRE/c1E8ZyF2jXnET7MJskereWOXher4CJuYjrI5esN0Az/1NPMD4KeWUbampBGw2MGqabMPFIbg=="],
+    "happy-dom": ["happy-dom@20.10.6", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -56,7 +56,7 @@
     "@vitest/coverage-istanbul": "^4.1.9",
     "eslint": "^10.5.0",
     "eslint-config-next": "^16.2.9",
-    "happy-dom": "^20.10.5",
+    "happy-dom": "^20.10.6",
     "tailwindcss": "^4.3.1",
     "typescript": "^6.0.3",
     "vitest": "^4.1.9"


### PR DESCRIPTION
## Summary

- Bump happy-dom from 20.10.5 to 20.10.6 in dashboard
- Sync dashboard bun.lock specifier to match the package.json caret range

## Verification

- SDE: bun install --frozen-lockfile; dashboard unit tests 557/557 passed
- Reviewer-04: bun install --frozen-lockfile, lockfile-only no-diff check, bun audit, and dashboard unit tests 557/557 passed

Closes #99
