### PR TITLE
chore(ci): pin base-ci reusable workflow to v2026.5 SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   quality:
-    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@v2026.4
+    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@aec4adc1a817c56790d1698329ef9398a15a754a  # v2026.5
     with:
       ignore-scripts: true
       trusted-native-deps: "better-sqlite3"


### PR DESCRIPTION
## Summary

Pin `nocoo/base-ci` reusable workflow reference in `.github/workflows/ci.yml` from floating tag `@v2026.4` to immutable commit SHA `aec4adc1a817c56790d1698329ef9398a15a754a` (v2026.5).

- Replaces `@v2026.4` → `@aec4adc1a817c56790d1698329ef9398a15a754a  # v2026.5`
- Floating `@v2026.x` tags can silently move if the base-ci repo retags or force-pushes — SHA pinning ensures the referenced workflow is byte-immutable even if upstream is compromised.

## Verification

- `rg "@v2026" .github/workflows/` — no remaining floating tag references
- `actionlint .github/workflows/*.yml` — clean

Resolves STU-901.