### PR TITLE
chore(security): pin bunfig.toml [install] ignoreScripts=true

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,30 @@ bun run build   # 生产构建
 binding（如 `better-sqlite3` 触发的 `node-gyp` / `binding.gyp`）供应链 RCE 风险。
 `bun.lock` 走 prebuilt binary，默认无需运行任何脚本即可安装。
 
-如需要为某个包临时启用构建脚本（升级后 prebuilt 不可用、新平台无 prebuilt 等），按需运行：
+### 何时需要为某个包临时启用构建脚本？
+
+升级后 prebuilt 不可用、当前平台无 prebuilt、或上游强依赖 `postinstall` 时。**在
+`ignoreScripts = true` 仍然生效的前提下**，无论是 `bun install --trust <pkg>`、
+`bun pm trust <pkg>`，还是 `package.json` 的 `trustedDependencies`，都**不会**
+执行脚本——`ignoreScripts` 会盖过它们。
+
+经实测可生效的临时流程（执行完务必恢复，不要合入仓库）：
 
 ```bash
-bun install --trusted=better-sqlite3
+# 1. 临时关掉 ignoreScripts —— 二选一即可：
+#    a) 改 bunfig.toml：ignoreScripts = false
+#    b) 暂时移走：mv bunfig.toml bunfig.toml.off
+# 2. 把目标包加入 package.json 的 trustedDependencies，例如：
+#    "trustedDependencies": ["better-sqlite3"]
+# 3. 重新安装，脚本会按 trustedDependencies 名单运行：
+rm -rf node_modules && bun install
+# 4. 验证构建产物已生成（如 node_modules/<pkg>/build/Release/*.node）
+# 5. 恢复 bunfig.toml（保持 ignoreScripts = true）
+#    并把第 2 步加入的 trustedDependencies 移除（除非项目想长期信任，但那时
+#    也需要明白 ignoreScripts 仍会压过它，下次再触发同样需要本流程）
 ```
 
-`--trusted` 仅作用于本次安装，不会写入配置；恢复默认时直接重新 `bun install` 即可。
+> ⚠️ 实测注意：
+> - `bun install --trusted=<pkg>` 不是真实 flag（bun 1.3.14 只有 `--trust`），写错时 CLI 也可能静默返回 0，**不能**用"命令不报错"证明它生效。
+> - `bun install --trust <pkg>` 会**写入** `package.json` 的 `trustedDependencies`，并不是"仅本次有效"。
+> - 唯一可靠的判定：检查包内是否生成预期的 build 产物（例如 native `.node` 文件）。

--- a/README.md
+++ b/README.md
@@ -74,3 +74,17 @@ bun run build   # 生产构建
 - Husky 目录：`.husky/`
 - `core.hooksPath` 必须指向根目录 `.husky`
 - hooks 会强制执行 UT 与 Lint
+
+## 🔒 依赖安装安全（bunfig.toml）
+仓库根的 `bunfig.toml` 启用 `[install] ignoreScripts = true`，禁用所有依赖的
+`preinstall` / `install` / `postinstall` / `prepare` 生命周期脚本，规避 native
+binding（如 `better-sqlite3` 触发的 `node-gyp` / `binding.gyp`）供应链 RCE 风险。
+`bun.lock` 走 prebuilt binary，默认无需运行任何脚本即可安装。
+
+如需要为某个包临时启用构建脚本（升级后 prebuilt 不可用、新平台无 prebuilt 等），按需运行：
+
+```bash
+bun install --trusted=better-sqlite3
+```
+
+`--trusted` 仅作用于本次安装，不会写入配置；恢复默认时直接重新 `bun install` 即可。

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,4 +1,10 @@
 [install]
-# Disable lifecycle scripts to mitigate supply-chain RCE via native bindings
-# (e.g. node-gyp/binding.gyp). Override per-package with `bun install --trusted=<pkg>`.
+# Disable lifecycle scripts (preinstall / install / postinstall / prepare) for ALL
+# dependencies — including those listed in package.json `trustedDependencies` — to
+# mitigate supply-chain RCE via native bindings (node-gyp / binding.gyp).
+#
+# This setting overrides per-package trust: as long as it is on, neither
+# `trustedDependencies` nor `bun pm trust <pkg>` nor `bun install --trust <pkg>`
+# will run any package's scripts. See README.md → "依赖安装安全" for the rare
+# fallback procedure when a dependency genuinely needs to build from source.
 ignoreScripts = true

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,4 @@
+[install]
+# Disable lifecycle scripts to mitigate supply-chain RCE via native bindings
+# (e.g. node-gyp/binding.gyp). Override per-package with `bun install --trusted=<pkg>`.
+ignoreScripts = true


### PR DESCRIPTION
## 🛡️ supply-chain: pin bunfig.toml [install] ignoreScripts=true

Closes STU-1155

### Summary

仓库根新增 `bunfig.toml`，强制禁用所有依赖的 `preinstall` / `install` / `postinstall` / `prepare` 生命周期脚本，规避 native binding 包（如 `better-sqlite3` 的 `node-gyp` / `binding.gyp`）供应链 RCE 风险。`bun.lock` 走 prebuilt binary，默认无需运行任何脚本即可安装。

### Flag 名与 fallback 流程：两轮实测纠正

原 issue 描述与一审 fallback 都存在事实错误，已经过本仓库 + 临时 canary 包（postinstall 写哨兵文件）实测，纠正到合入版本：

| 写法 | bun 1.3.14 实际行为 |
|---|---|
| `[install] scripts = false` | ❌ 未识别 key，静默忽略，**无防护** |
| `[install] ignoreScripts = true` | ✅ 真实 key（对应 CLI `--ignore-scripts`） |
| `bun install --trusted=<pkg>` | ❌ 该 flag 不存在；真实是 `--trust` |
| `bun install --trust <pkg>` | ⚠️ 会**写入** `package.json` 的 `trustedDependencies`，并非一次性 |
| `ignoreScripts=true` + `trustedDependencies` / `bun pm trust` / `--trust` | ❌ 全部不运行脚本——`ignoreScripts` 覆盖所有 trust 路径 |
| 临时把 `ignoreScripts` 切到 `false`（或挪走 bunfig.toml）+ `trustedDependencies` + `bun install` | ✅ 唯一实测可生效的 fallback |

`README.md` 的「依赖安装安全」段落给出经实测可生效的临时构建流程，并明确警告不能用"`--trust` 不报错"证明脚本运行——必须验证 `.node` 等构建产物是否生成。

### Commits

- `479a72d` `chore(security): pin bunfig.toml [install] ignoreScripts=true`
- `5da52a5` `docs(security): rewrite trust fallback to a verified procedure`

### Test plan

- [x] `rm -rf node_modules dashboard/node_modules && bun install` → root 181 packages，dashboard 601 packages
- [x] `bun install --force 2>&1 | grep -iE "build|compile|gyp"` → 无输出
- [x] `dashboard/node_modules/better-sqlite3/build/Release/better_sqlite3.node` 存在（v12.11.1 prebuilt）
- [x] `bun run ut:scripts` (root)：13 files / 127 tests passed，coverage 100% lines
- [x] `bun run ut` (dashboard)：47 files / 557 tests passed，coverage 99.51% stmts / 95.94% branch
- [ ] CI 一次跑通（待本 PR 触发）

### Reviewer 注意

请勿按旧的 `scripts=false` / `--trusted=<pkg>` 口径回滚——那些是 bun 1.3.14 不识别 / 不存在的写法。详见 PR diff 中 README.md 「依赖安装安全」段落与 bunfig.toml 注释。
