### PR TITLE
chore(deps): bump @types/node 26.0.0 → 26.0.1 in dashboard

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,8 +7,8 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/bun": "^1.3.14",
-        "@typescript-eslint/eslint-plugin": "8.62.0",
-        "@typescript-eslint/parser": "8.62.0",
+        "@typescript-eslint/eslint-plugin": "^8.62.0",
+        "@typescript-eslint/parser": "^8.62.0",
         "@vitest/coverage-istanbul": "^4.1.9",
         "eslint": "^10.5.0",
         "eslint-config-prettier": "^10.1.8",

--- a/dashboard/bun.lock
+++ b/dashboard/bun.lock
@@ -43,7 +43,7 @@
         "@types/leaflet": "^1.9.21",
         "@types/leaflet-draw": "^1.0.13",
         "@types/leaflet.markercluster": "^1.5.6",
-        "@types/node": "^26",
+        "@types/node": "^26.0.1",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^6.0.3",
@@ -495,7 +495,7 @@
 
     "@types/leaflet.markercluster": ["@types/leaflet.markercluster@1.5.6", "", { "dependencies": { "@types/leaflet": "^1.9" } }, "sha512-I7hZjO2+isVXGYWzKxBp8PsCzAYCJBc29qBdFpquOCkS7zFDqUsUvkEOyQHedsk/Cy5tocQzf+Ndorm5W9YKTQ=="],
 
-    "@types/node": ["@types/node@26.0.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA=="],
+    "@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
 
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -49,7 +49,7 @@
     "@types/leaflet": "^1.9.21",
     "@types/leaflet-draw": "^1.0.13",
     "@types/leaflet.markercluster": "^1.5.6",
-    "@types/node": "^26",
+    "@types/node": "^26.0.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6.0.3",


### PR DESCRIPTION
## Summary
- Bump `@types/node` from `26.0.0` → `26.0.1` in `dashboard/devDependencies` (patch).
- Lockfiles regenerated after `rm -rf node_modules .next` clean reinstall.

Closes #115

## Verification
- `bun install --frozen-lockfile` (root + dashboard) ✅
- `bun run typecheck` ✅
- `bun run lint` ✅
- `bun run test` ✅ (root 127 + dashboard 557 tests)