### PR TITLE
chore(deps): bump lucide-react 1.21.0 → 1.22.0 in dashboard

### DIFF
--- a/dashboard/bun.lock
+++ b/dashboard/bun.lock
@@ -16,7 +16,7 @@
         "leaflet-draw": "^1.0.4",
         "leaflet.fullscreen": "^5.3.1",
         "leaflet.markercluster": "^1.5.3",
-        "lucide-react": "^1.21.0",
+        "lucide-react": "1.22.0",
         "next": "^16.2.9",
         "next-auth": "^5.0.0-beta.30",
         "next-themes": "^0.4.6",
@@ -48,7 +48,7 @@
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^6.0.3",
         "@vitest/coverage-istanbul": "^4.1.9",
-        "eslint": "10.6.0",
+        "eslint": "^10.6.0",
         "eslint-config-next": "^16.2.9",
         "happy-dom": "^20.10.6",
         "tailwindcss": "^4.3.1",
@@ -1035,7 +1035,7 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
-    "lucide-react": ["lucide-react@1.21.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-reEZMXq8Qdd5jg5XYkQ5TR1fB/GiQ7ih4vcrthYDtgjSDwh0i6/YLiGjsWsIwgN49gpAnd4J2elSNzncMEEUUQ=="],
+    "lucide-react": ["lucide-react@1.22.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-c9o3l0PiNcgOQDW4F31BEYHudE7kgxVt3o30qMl36ZPwTxXlGB4QnLilhERvVM4uh/pl5MDyY1/gzZSYcHDtBg=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -22,7 +22,7 @@
     "leaflet-draw": "^1.0.4",
     "leaflet.fullscreen": "^5.3.1",
     "leaflet.markercluster": "^1.5.3",
-    "lucide-react": "^1.21.0",
+    "lucide-react": "1.22.0",
     "next": "^16.2.9",
     "next-auth": "^5.0.0-beta.30",
     "next-themes": "^0.4.6",


### PR DESCRIPTION
## Summary

- Bump `lucide-react` from `1.21.0` → `1.22.0` in `dashboard/` (minor, semver-compatible)
- Tracks GitHub issue [#119](https://github.com/nocoo/life.ai/issues/119), Multica STU-1424

## Verification

- `bun run lint` ✅
- `bun run ut` ✅ — 47 files, 557 tests pass; coverage 99.51% stmts / 95.94% branches
- `bun run build` ✅
- `osv-scanner --lockfile dashboard/bun.lock` ✅ — no issues
